### PR TITLE
Adjust timer use to alleviate flicker on scroll up

### DIFF
--- a/autoload/comfortable_motion.vim
+++ b/autoload/comfortable_motion.vim
@@ -67,6 +67,7 @@ function! s:tick(timer_id)
   else
     " Do nothing
   endif
+  redraw
 
   " Stop the thread or continue it
   if abs(l:st.velocity) < 1


### PR DESCRIPTION
I reworked the timer logic to have one timer running constantly running against the physics state. I believe that doing so reduces overheads/delays caused by repeatedly scheduling callbacks as in the original code. To keep the timer overhead light, the callback function is modified to short-circuit in cases where scrolling is not expected to take place.

On my machine, this resolves issue #17 (bad flickering scrolling up), which I experienced with vim in xterm ($TERM set to xterm-256color). I'd be interested to see feedback from others.

By the way, thanks for the cool plugin!