### PR TITLE
Add some scrolling aliases to call flick

### DIFF
--- a/plugin/comfortable_motion.vim
+++ b/plugin/comfortable_motion.vim
@@ -22,6 +22,16 @@ if !exists('g:comfortable_motion_no_default_key_mappings') ||
 
   nnoremap <silent> <C-f> :call comfortable_motion#flick(200)<CR>
   nnoremap <silent> <C-b> :call comfortable_motion#flick(-200)<CR>
+
+  nnoremap <silent> <PageDown> :call comfortable_motion#flick(200)<CR>
+  nnoremap <silent> <PageUp> :call comfortable_motion#flick(-200)<CR>
+  inoremap <silent> <PageDown> <C-O>:call comfortable_motion#flick(200)<CR>
+  inoremap <silent> <PageUp> <C-O>:call comfortable_motion#flick(-200)<CR>
+
+  nnoremap <silent> <S-Down> :call comfortable_motion#flick(200)<CR>
+  nnoremap <silent> <S-Up> :call comfortable_motion#flick(-200)<CR>
+  inoremap <silent> <S-Down> <C-O>:call comfortable_motion#flick(200)<CR>
+  inoremap <silent> <S-Up> <C-O>:call comfortable_motion#flick(-200)<CR>
 endif
 
 

--- a/plugin/comfortable_motion.vim
+++ b/plugin/comfortable_motion.vim
@@ -23,15 +23,15 @@ if !exists('g:comfortable_motion_no_default_key_mappings') ||
   nnoremap <silent> <C-f> :call comfortable_motion#flick(200)<CR>
   nnoremap <silent> <C-b> :call comfortable_motion#flick(-200)<CR>
 
-  nnoremap <silent> <PageDown> :call comfortable_motion#flick(200)<CR>
-  nnoremap <silent> <PageUp> :call comfortable_motion#flick(-200)<CR>
-  inoremap <silent> <PageDown> <C-O>:call comfortable_motion#flick(200)<CR>
-  inoremap <silent> <PageUp> <C-O>:call comfortable_motion#flick(-200)<CR>
+  nmap <silent> <PageDown> <C-f>
+  nmap <silent> <PageUp> <C-b>
+  imap <silent> <PageDown> <C-O><C-f>
+  imap <silent> <PageUp> <C-O><C-b>
 
-  nnoremap <silent> <S-Down> :call comfortable_motion#flick(200)<CR>
-  nnoremap <silent> <S-Up> :call comfortable_motion#flick(-200)<CR>
-  inoremap <silent> <S-Down> <C-O>:call comfortable_motion#flick(200)<CR>
-  inoremap <silent> <S-Up> <C-O>:call comfortable_motion#flick(-200)<CR>
+  nmap <silent> <S-Down> <C-f>
+  nmap <silent> <S-Up> <C-b>
+  imap <silent> <S-Down> <C-O><C-f>
+  imap <silent> <S-Up> <C-O><C-b>
 endif
 
 


### PR DESCRIPTION
Some aliases of C-f and C-b for scrolling one page down and up are:
PageDown and PageUp, Shifh-Down and Shift-Up on either normal or insert
mode.  This fix adds comfortable_motion for those aliases.

resolves #41 