### PR TITLE
Added stop function and use it when user enters Terminal mode

### DIFF
--- a/autoload/comfortable_motion.vim
+++ b/autoload/comfortable_motion.vim
@@ -87,5 +87,9 @@ function! comfortable_motion#flick(impulse)
   let s:comfortable_motion_state.impulse += a:impulse
 endfunction
 
+function! comfortable_motion#stop()
+  let s:comfortable_motion_state.velocity = 0.0
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/comfortable_motion.vim
+++ b/plugin/comfortable_motion.vim
@@ -24,6 +24,7 @@ if !exists('g:comfortable_motion_no_default_key_mappings') ||
   nnoremap <silent> <C-b> :call comfortable_motion#flick(-200)<CR>
 endif
 
+autocmd TermEnter * call comfortable_motion#stop()
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Without this patch, when user enters terminal mode, while scrolling the buffer, it doesn't stop scrolling which results in an error while processing tick function.
This patch makes it so when user enters terminal mode, while still scrolling; they aren't interrupted with multiple error messages.